### PR TITLE
[bug] fix tx:sign doesn't work

### DIFF
--- a/src/commands/tx/sign.ts
+++ b/src/commands/tx/sign.ts
@@ -85,13 +85,13 @@ class TxSignCommand extends Command {
       ])
 
       from = responses.account;
+      const internalFrom = base.getAccountByName(from);
+
       passphrase = responses.passphrase;
     }
 
     // Initialize zilliqa and wallet
     const zilliqa = new Zilliqa(base.apiAddress);
-
-    const internalFrom = base.getAccountByName(from);
 
     const internalAccount = (usePrivateKey === true)
       ? await zilliqa.wallet.addByPrivateKey(privateKey)


### PR DESCRIPTION
`internalFrom` no need when signing tx using private key
it will failed because `from` will not be declared when using private key